### PR TITLE
Update base image to Python 3.12

### DIFF
--- a/dockerfiles/Dockerfile.debug
+++ b/dockerfiles/Dockerfile.debug
@@ -18,7 +18,7 @@
 # ##########################################################################
 # Base Image
 # ##########################################################################
-FROM mcr.microsoft.com/devcontainers/python:latest AS base
+FROM mcr.microsoft.com/devcontainers/python:3.12 AS base
 
 # ##########################################################################
 # Maintainer


### PR DESCRIPTION
This pull request makes a small but important update to the base image used in the `dockerfiles/Dockerfile.debug` file. The change ensures that the development container uses Python version 3.12 instead of the latest available version, which helps maintain consistency and compatibility.

* Updated the base image in `dockerfiles/Dockerfile.debug` to use `mcr.microsoft.com/devcontainers/python:3.12` instead of the generic latest tag, ensuring the environment uses Python 3.12 specifically.