### PR TITLE
Add pip and docker package ecosystems to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,7 +12,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This pull request makes updates to the `.github/dependabot.yaml` configuration to improve automated dependency management. The main change is the addition of support for new package ecosystems.

Dependabot configuration enhancements:

* Added support for the `pip` package ecosystem, enabling weekly checks for Python dependencies.
* Added support for the `docker` package ecosystem, enabling weekly checks for Docker dependencies.