### PR TITLE
Update ex_test.py

### DIFF
--- a/pythontemplate/tests/ex_test.py
+++ b/pythontemplate/tests/ex_test.py
@@ -12,10 +12,8 @@ class TestStringMethods(unittest.TestCase):
 
     def test_split(self):
         s = 'hello world'
-        s_lst = list(s)
-
-        self.assertEqual(s.split(), s_lst)
 
 
+        self.assertEqual(s.split(), ['hello', 'world'])
 if __name__ == '__main__':
     unittest.main()

--- a/pythontemplate/tests/ex_test.py
+++ b/pythontemplate/tests/ex_test.py
@@ -12,10 +12,9 @@ class TestStringMethods(unittest.TestCase):
 
     def test_split(self):
         s = 'hello world'
-        self.assertEqual(s.split(), ['hello', 'world'])
-        # check that s.split fails when the separator is not a string
-        with self.assertRaises(TypeError):
-            s.split(2)
+        s_lst = list(s)
+
+        self.assertEqual(s.split(), s_lst)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request makes a small change to the `test_split` method in the `pythontemplate/tests/ex_test.py` file. The test now compares the result of `s.split()` to a list of individual characters, rather than the expected list of words, and removes the test for a `TypeError` when passing a non-string separator.